### PR TITLE
Fire event when history is opened or closed

### DIFF
--- a/src/scripts/PhyloCanvas.js
+++ b/src/scripts/PhyloCanvas.js
@@ -2658,6 +2658,7 @@
     } else {
       this.collapse();
     }
+    fireEvent(this.tree.canvasEl, 'historyopen', { isOpen: !this.isCollapsed() });
   }
 
   History.prototype.createDiv = function (parentDiv) {
@@ -2679,7 +2680,7 @@
     div.appendChild(tabDiv);
     this.toggleDiv = tabDiv;
 
-    return div
+    return div;
   }
 
   History.prototype.resizeTree = function () {

--- a/src/scripts/PhyloCanvas.js
+++ b/src/scripts/PhyloCanvas.js
@@ -2658,7 +2658,7 @@
     } else {
       this.collapse();
     }
-    fireEvent(this.tree.canvasEl, 'historyopen', { isOpen: !this.isCollapsed() });
+    fireEvent(this.tree.canvasEl, 'historytoggle', { isOpen: !this.isCollapsed() });
   }
 
   History.prototype.createDiv = function (parentDiv) {

--- a/src/scripts/demo.js
+++ b/src/scripts/demo.js
@@ -10,7 +10,7 @@ window.onload = function(){
     // load tree via AJAX and render using default params
     phylocanvas.load('./tree.nwk');
 
-    phylocanvas.canvasEl.addEventListener('historyopen', function (e) {
+    phylocanvas.on('historytoggle', function (e) {
       alert(e.isOpen ? 'history is open' : 'history is closed');
     });
 

--- a/src/scripts/demo.js
+++ b/src/scripts/demo.js
@@ -10,6 +10,10 @@ window.onload = function(){
     // load tree via AJAX and render using default params
     phylocanvas.load('./tree.nwk');
 
+    phylocanvas.canvasEl.addEventListener('historyopen', function (e) {
+      alert(e.isOpen ? 'history is open' : 'history is closed');
+    });
+
     window.phylocanvas = phylocanvas;
 
 


### PR DESCRIPTION
Allow applications to respond to the visibility of the history tab now that clicks do not propagate.