### PR TITLE
Optional History and Scaling Fix

### DIFF
--- a/src/demo.html
+++ b/src/demo.html
@@ -11,7 +11,7 @@
 
             #phylocanvas
             {
-                width: 30%;
+                width: 100%;
                 height: 400px;
             }
         </style>

--- a/src/demo.html
+++ b/src/demo.html
@@ -1,27 +1,25 @@
 <!DOCTYPE html>
 <html>
-    <head>
-        <link rel="stylesheet" type="text/css" href="styles/PhyloCanvas.css" />
-        <style>
-            body
-            {
-                margin: 10px auto;
-                max-width: 1200px;
-            }
+<head>
+  <style>
+    body
+    {
+      margin: 10px auto;
+      max-width: 1200px;
+    }
 
-            #phylocanvas
-            {
-                width: 100%;
-                height: 400px;
-            }
-        </style>
-    </head>
+    #phylocanvas
+    {
+      width: 100%;
+      height: 400px;
+    }
+  </style>
+</head>
+<body>
+  <h1>A PhyloCanvas Demo</h1>
+  <div id="phylocanvas" ></div>
 
-    <body>
-        <h1>A PhyloCanvas Demo</h1>
-        <div id="phylocanvas" ></div>
-
-        <script type="application/javascript" src="scripts/PhyloCanvas.js"></script>
-        <script type="application/javascript" src="scripts/demo.js"></script>
-    </body>
+  <script type="application/javascript" src="scripts/PhyloCanvas.js"></script>
+  <script type="application/javascript" src="scripts/demo.js"></script>
+</body>
 </html>

--- a/src/scripts/PhyloCanvas.js
+++ b/src/scripts/PhyloCanvas.js
@@ -589,12 +589,7 @@
 
     this.adjustForPixelRatio();
 
-    if (conf.history || conf.history === undefined) {
-      var collapsed = (conf.history && conf.history.collapsed);
-      this.historyCollapsed = collapsed || true;
-      this.historySnapshots = [];
-      this.history = new History(this);
-    }
+    this.initialiseHistory(conf);
 
     this.addListener('contextmenu', this.clicked.bind(this));
     this.addListener('click', this.clicked.bind(this));
@@ -2605,6 +2600,17 @@
     this.setSize(this.canvasEl.offsetWidth, this.canvasEl.offsetHeight)
     this.draw();
     this.history.resizeTree();
+  }
+
+  Tree.prototype.initialiseHistory = function (config) {
+    var isCollapsedConfigured;
+
+    if (config.history || typeof config.history === 'undefined') {
+      isCollapsedConfigured = (config.history && typeof config.history.collapsed !== 'undefined')
+      this.historyCollapsed = isCollapsedConfigured ? config.history.collapsed : true;
+      this.historySnapshots = [];
+      this.history = new History(this);
+    }
   }
 
   function History(tree) {

--- a/src/scripts/PhyloCanvas.js
+++ b/src/scripts/PhyloCanvas.js
@@ -589,8 +589,9 @@
 
     this.adjustForPixelRatio();
 
-    if (conf.history) {
-      this.historyCollapsed = (conf.history.collapsed !== undefined) ? conf.history.collapsed : true;
+    if (conf.history || conf.history === undefined) {
+      var collapsed = (conf.history && conf.history.collapsed);
+      this.historyCollapsed = collapsed || true;
       this.historySnapshots = [];
       this.history = new History(this);
     }

--- a/src/scripts/PhyloCanvas.js
+++ b/src/scripts/PhyloCanvas.js
@@ -587,14 +587,13 @@
       this.navigator = new Navigator(this);
     }
 
-    this.historyCollapsed = (conf.historyCollapsed !== undefined) ?
-    conf.historyCollapsed : true;
-
-    this.historySnapshots = [];
-
-    this.history = new History(this);
-
     this.adjustForPixelRatio();
+
+    if (conf.history) {
+      this.historyCollapsed = (conf.history.collapsed !== undefined) ? conf.history.collapsed : true;
+      this.historySnapshots = [];
+      this.history = new History(this);
+    }
 
     this.addListener('contextmenu', this.clicked.bind(this));
     this.addListener('click', this.clicked.bind(this));

--- a/src/scripts/PhyloCanvas.js
+++ b/src/scripts/PhyloCanvas.js
@@ -1626,7 +1626,7 @@
           }
           this.draw();
         } else if (this.unselectOnClickAway && !this.dragging) {
-          this.root.setSelected(false, true);
+          // this.root.setSelected(false, true);
           this.draw();
         }
 
@@ -2393,18 +2393,20 @@
     setSize: function (width, height) {
       this.canvas.canvas.width = width;
       this.canvas.canvas.height = height;
+      if (this.navigator) {
+        this.navigator.resize();
+      }
+      this.adjustForPixelRatio();
       if (this.drawn) {
         this.draw();
       }
-      if (this.navigator)this.navigator.resize();
-      this.adjustForPixelRatio();
     },
     setZoom: function (z) {
       if (z > -2 && z < 2) {
         var oz = this.zoom;
         this.zoom = Math.pow(10, z);
 
-        this.offsetx = (this.offsetx / oz) * this.zoom ;
+        this.offsetx = (this.offsetx / oz) * this.zoom;
         this.offsety = (this.offsety / oz) * this.zoom;
 
         this.draw();

--- a/src/scripts/demo.js
+++ b/src/scripts/demo.js
@@ -1,20 +1,22 @@
 window.onload = function(){
-   "use strict";
+ "use strict";
 
-    // Construct tree object
-    var phylocanvas = new PhyloCanvas.Tree('phylocanvas', { historyCollapsed: true });
-    phylocanvas.showLabels = true;
-    phylocanvas.hoverLabel = true;
-    phylocanvas.setTreeType('rectangular');
+  // Construct tree object
+  var phylocanvas = new PhyloCanvas.Tree('phylocanvas', {
+    history: {
+      collapsed: true
+    }
+  });
+  phylocanvas.showLabels = true;
+  phylocanvas.hoverLabel = true;
+  phylocanvas.setTreeType('rectangular');
 
-    // load tree via AJAX and render using default params
-    phylocanvas.load('./tree.nwk');
+  // load tree via AJAX and render using default params
+  phylocanvas.load('./tree.nwk');
 
-    phylocanvas.on('historytoggle', function (e) {
-      alert(e.isOpen ? 'history is open' : 'history is closed');
-    });
+  phylocanvas.on('historytoggle', function (e) {
+    alert(e.isOpen ? 'history is open' : 'history is closed');
+  });
 
-    window.phylocanvas = phylocanvas;
-
-
+  window.phylocanvas = phylocanvas;
 };

--- a/src/scripts/demo.js
+++ b/src/scripts/demo.js
@@ -14,9 +14,9 @@ window.onload = function(){
   // load tree via AJAX and render using default params
   phylocanvas.load('./tree.nwk');
 
-  phylocanvas.on('historytoggle', function (e) {
-    alert(e.isOpen ? 'history is open' : 'history is closed');
-  });
+  // phylocanvas.on('historytoggle', function (e) {
+  //   alert(e.isOpen ? 'history is open' : 'history is closed');
+  // });
 
   window.phylocanvas = phylocanvas;
 };


### PR DESCRIPTION
The history can now be made optional through config, and scaling issue is temporarily worked around, needs proper solution in the future.

N.B. this is a breaking change for the documentation and demos that rely on history.

EDIT: Now not so much a breaking change, but the old `historyCollapsed` property is deprecated in favour of `{ history: { collapsed: false } }`